### PR TITLE
fix commit permission denied for home dipy folder

### DIFF
--- a/modules/connectomics/processes/commit.nf
+++ b/modules/connectomics/processes/commit.nf
@@ -26,6 +26,7 @@ process COMMIT {
 
     if ( params.use_commit2 && !params.use_both_commit ) {
     """
+    export DIPY_HOME="./"
     scil_run_commit.py $h5 $dwi $bval $bvec "${sid}__results_bzs/" --ball_stick --commit2 \
         --processes $params.processes_commit --b_thr $params.b_thr --nbr_dir $params.nbr_dir\
         $para_diff_arg $iso_diff_arg
@@ -34,6 +35,7 @@ process COMMIT {
     }
     else if ( params.use_both_commit ) {
     """
+    export DIPY_HOME="./"
     scil_run_commit.py $h5 $dwi $bval $bvec "${sid}__results_bzs_1/" --ball_stick --commit2 \
         --processes $params.processes_commit --b_thr $params.b_thr --nbr_dir $params.nbr_dir\
         $para_diff_arg $iso_diff_arg
@@ -45,6 +47,7 @@ process COMMIT {
     }
     else {
     """
+    export DIPY_HOME="./"
     scil_run_commit.py $h5 $dwi $bval $bvec "${sid}__results_bzs/" --in_peaks $peaks \
         --processes $params.processes_commit --b_thr $params.b_thr --nbr_dir $params.nbr_dir $ball_stick_arg \
         $para_diff_arg $iso_diff_arg $perp_diff_arg
@@ -76,6 +79,7 @@ process COMMIT_ON_TRK {
         perp_diff_arg="--perp_diff $params.perp_diff"
     }
     """
+    export DIPY_HOME="./"
     scil_run_commit.py $trk_h5 $dwi $bval $bvec "${sid}__results_bzs/" --in_peaks $peaks \
         --processes $params.processes_commit --b_thr $params.b_thr --nbr_dir $params.nbr_dir $ball_stick_arg \
         --para_diff $params.para_diff $perp_diff_arg --iso_diff $params.iso_diff


### PR DESCRIPTION
The COMMIT process was failing due to a OSError: 
```bash
Traceback (most recent call last):
  File "/usr/local/bin/scil_run_commit.py", line 33, in <module>
    sys.exit(load_entry_point('scilpy', 'console_scripts', 'scil_run_commit.py')())
  File "/scilpy/scripts/scil_run_commit.py", line 408, in main
    commit.core.setup(ndirs=args.nbr_dir)
  File "commit/core.pyx", line 38, in commit.core.setup
  File "/usr/local/lib/python3.10/dist-packages/amico/core.py", line 41, in setup
    amico.lut.precompute_rotation_matrices( lmax, n )
  File "/usr/local/lib/python3.10/dist-packages/amico/lut.py", line 102, in precompute_rotation_matrices
    makedirs(dipy_home)
  File "/usr/lib/python3.10/os.py", line 225, in makedirs
    mkdir(name, mode)
OSError: [Errno 30] Read-only file system: '/home/lthorn2/.dipy'
```
After some digging, `dipy` is trying to create his home directory at `~/.dipy` which is not writeable within a container.
Setting the `DIPY_HOME` variable to another path should be a sufficient fix.